### PR TITLE
Handle nested f string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-01-23
+
+### Changed
+
+- Handle nested f-string better. Only add f if it is used as an index to access array elements. Any other specific use cases are to be implemented when one is discovered that is not handled correctly.
+- Bump the major.
+
 ## [0.1.2] - 2022-01-23
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -150,9 +150,20 @@ export const getQuoteRanges = (input: string): QuoteRangeType[] => {
         lastQuoteUsed = currentChar;
       } else {
         if (lastQuoteUsed !== currentChar) {
-          quoteStack.push({ start: quoteStartIndex, quoteUsed: lastQuoteUsed });
-          quoteStartIndex = index;
-          lastQuoteUsed = currentChar;
+          let squareBracketOpened = false;
+          for (let anotherIndex = index - 1; anotherIndex > 0; anotherIndex--) {
+            if (input[anotherIndex] === "[") {
+              squareBracketOpened = true;
+              break;
+            } else if (input[anotherIndex] !== " ") {
+              break;
+            }
+          }
+          if (squareBracketOpened) {
+            quoteStack.push({ start: quoteStartIndex, quoteUsed: lastQuoteUsed });
+            quoteStartIndex = index;
+            lastQuoteUsed = currentChar;
+          }
         } else {
           quoteEndIndex = index;
         }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -333,7 +333,7 @@ print(fstring)`,
   });
 });
 
-suite.skip("isFString validation", () => {
+suite("isFString validation", () => {
   const testData: [string, boolean][] = [
     ["''", false],
     ["f''", false],
@@ -376,7 +376,7 @@ suite.skip("isFString validation", () => {
   });
 });
 
-suite.skip("getQuoteRanges validation", () => {
+suite("getQuoteRanges validation", () => {
   const doubleQuote = '"',
     singleQuote = "'",
     testData = [singleQuote, doubleQuote];
@@ -430,6 +430,17 @@ suite.skip("getQuoteRanges validation", () => {
           [17, 30, false, true],
           [4, 10, false, true],
           [0, 13, false, true],
+        ],
+      ],
+      [`${quote}a ${otherQuote}{b}${otherQuote}${quote}`, [[0, 8, false, true]]],
+      [
+        `${quote}a ${otherQuote}{b}${otherQuote}${quote} + ${quote}a ${otherQuote}{b}${otherQuote}${quote} + ${quote}a${otherQuote}{b}${otherQuote}${quote} + ${quote}a[${otherQuote}{b}${otherQuote}]${quote}`,
+        [
+          [38, 42, false, true],
+          [35, 44, false, true],
+          [24, 31, false, true],
+          [12, 20, false, true],
+          [0, 8, false, true],
         ],
       ],
     ];


### PR DESCRIPTION
closes #3 

Handle nested f-string better. Only add f if it is used as an index to access array elements. Any other specific use cases are to be implemented when one is discovered that is not handled correctly.