### PR TITLE
ci warning fix for node version 12 usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
       - name: clean install dependencies
         run: npm ci
 
-      - name: Run test
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: npm run test
+      - name: Run tests (Linux)
+        run: xvfb-run -a npm test
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
+      - name: Run tests (Windows/Mac)
+        run: npm test
+        if: ${{ matrix.os != 'ubuntu-latest' }}
 
       - name: Publish to VSCode marketplace
         if: success() && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "18"
 
       - name: clean install dependencies
         run: npm ci

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -11,8 +11,13 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
       - name: install gitversion tool
-        uses: gittools/actions/gitversion/setup@v0.9.4
+        uses: gittools/actions/gitversion/setup@v0.9.15
         with:
           versionSpec: "5.x"
         env:
@@ -20,7 +25,7 @@ jobs:
 
       - name: execute gitversion
         id: gitversion # step id used as reference for output values
-        uses: gittools/actions/gitversion/execute@v0.9.4
+        uses: gittools/actions/gitversion/execute@v0.9.15
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 


### PR DESCRIPTION
- use xvfb-run directly instead of GabrielBB/xvfb-action
- node version bump in action
- try fixing node 12 warnings
